### PR TITLE
Add Default PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/feature
+++ b/.github/PULL_REQUEST_TEMPLATE/feature
@@ -1,0 +1,18 @@
+# Description
+*Provide a meaningful description of this PR*
+
+# How to Test
+*Provide instructions for how to test/run the feature*
+
+# Changes
+*Describe changes defined by the PR (provide some explanation of the changes to supplement the 'changed files' tab* 
+
+- *`/path/to/file1.py`*
+   - *Refactored `method01` from `class01` to handle*
+* *`/path/to/file2.py`*
+   * *Added `testClass` to encapsulate test logic*
+
+# References
+*Provide references to related issues, documentation, and external resources*
+
+closes #*{issue-id}*


### PR DESCRIPTION
This MR adds the .github/PULL_REQUEST_TEMPLATE/feature PR template which specifies a .md template for PR descriptions.

closes #41