### PR TITLE
Style: center the H2 headings on the homepage

### DIFF
--- a/style.css
+++ b/style.css
@@ -2971,9 +2971,9 @@ h4.font_themecolor {
     color: #252323;
     font-weight: 400;
     line-height: 55px;
-    width: auto;
-    float: left;
-    position: relative;
+    display: flex;
+        justify-content: center;
+        align-items: center;
 }
 
 .heading_s1 h2::first-letter {


### PR DESCRIPTION
# Description
*centre the H2 headings on the homepage to make the design more consistent and more usable*

# How to Test
*Provide instructions for how to test/run the feature*

# Changes
*changed the code from `float: left to `flexbox`* 



# References
*I live in Ghana. I played Far Cry 5 and decided to search for schools in Montana to apply for grad school in the fall of 2024. I saw  this website during my research and decided to do this little fix*

